### PR TITLE
fix(mage/mdbook) Use darwin URL when needed

### DIFF
--- a/tools/magefile.go
+++ b/tools/magefile.go
@@ -9,12 +9,14 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/magefile/mage/sh"
 )
 
 const (
-	mdbookURL = "https://github.com/rust-lang/mdBook/releases/download/v0.4.37/mdbook-v0.4.37-x86_64-unknown-linux-gnu.tar.gz"
+	mdbookLinuxURL   = "https://github.com/rust-lang/mdBook/releases/download/v0.4.37/mdbook-v0.4.37-x86_64-unknown-linux-gnu.tar.gz"
+	mdbookMacOSURL   = "https://github.com/rust-lang/mdBook/releases/download/v0.4.40/mdbook-v0.4.40-x86_64-apple-darwin.tar.gz"
 )
 
 var Default = Build
@@ -29,6 +31,12 @@ func Build() error {
 	here, err := os.Getwd()
 	if err != nil {
 		return err
+	}
+
+	mdbookURL := mdbookLinuxURL
+
+	if runtime.GOOS == "darwin" {
+		mdbookURL = mdbookMacOSURL
 	}
 
 	response, err := http.Get(mdbookURL)


### PR DESCRIPTION
The goal is that macos users can use mdbook installed with mage.