### PR TITLE
Holyhope/resource/virtual machine status

### DIFF
--- a/docs/resources/virtual_machine.md
+++ b/docs/resources/virtual_machine.md
@@ -43,6 +43,7 @@ output "ipv4" {
 - `enable_cloudinit` (Boolean) Whether or not to enable passing data through `cloudinit`. This uses the NoCloud iso image method; it will add a virtual CDROM drive (distinct from the one passed by `cd_path`) with the data in `cloudinit_userdata` and `cloudinit_hostname` when enabled
 - `enable_screen` (Boolean) Whether or not this VM should have a virtual screen, to use with the VNC websocket protocol
 - `os` (String) Type of OS used for this VM. Only used to set an icon for now
+- `status` (String) VM status
 - `timeouts` (Attributes) Timeouts for various operations expressed as strings such as `30s` or `2h45m` where valid time units are `s` (seconds), `m` (minutes) and `h` (hours) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only
@@ -50,7 +51,6 @@ output "ipv4" {
 - `id` (Number) Unique identifier of the VM
 - `mac` (String) VM ethernet interface MAC address
 - `networking` (Attributes Set) Network binds of the virtual machine (see [below for nested schema](#nestedatt--networking))
-- `status` (String) VM status
 
 <a id="nestedatt--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/internal/resource_virtual_machine.go
+++ b/internal/resource_virtual_machine.go
@@ -610,6 +610,8 @@ func (v *virtualMachineResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
+	expectedStatus := model.Status.ValueString()
+
 	payload, diagnostics := model.toClientPayload(ctx)
 	if diagnostics.HasError() {
 		resp.Diagnostics.Append(diagnostics...)
@@ -669,7 +671,7 @@ func (v *virtualMachineResource) Update(ctx context.Context, req resource.Update
 	}
 
 	// Start if needed
-	if model.Status.ValueString() == freeboxTypes.RunningStatus {
+	if expectedStatus == freeboxTypes.RunningStatus {
 		status, err := v.start(ctx, virtualMachine.ID)
 		model.Status = basetypes.NewStringValue(status)
 		if err != nil {

--- a/internal/resource_virtual_machine_test.go
+++ b/internal/resource_virtual_machine_test.go
@@ -29,6 +29,7 @@ var _ = Context("resource \"freebox_virtual_machine\" { ... }", Ordered, func() 
 								memory    = 300
 								name      = "` + name + `"
 								disk_type = "qcow2"
+								status    = "stopped"
 								disk_path = "` + existingDisk.filepath + `"
 								timeouts = {
 									kill       = "500ms" // The image used for tests hangs on SIGTERM and needs a SIGKILL to terminate
@@ -42,6 +43,7 @@ var _ = Context("resource \"freebox_virtual_machine\" { ... }", Ordered, func() 
 							resource.TestCheckResourceAttr("freebox_virtual_machine."+name, "memory", "300"),
 							resource.TestCheckResourceAttr("freebox_virtual_machine."+name, "disk_type", types.QCow2Disk),
 							resource.TestCheckResourceAttr("freebox_virtual_machine."+name, "disk_path", existingDisk.filepath),
+							resource.TestCheckResourceAttr("freebox_virtual_machine."+name, "status", "stopped"),
 							func(s *terraform.State) error {
 								identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_virtual_machine."+name].Primary.Attributes["id"])
 								Expect(err).To(BeNil())
@@ -52,6 +54,7 @@ var _ = Context("resource \"freebox_virtual_machine\" { ... }", Ordered, func() 
 								Expect(vm.Name).To(Equal(name))
 								Expect(vm.DiskType).To(Equal(types.QCow2Disk))
 								Expect(vm.DiskPath).To(Equal(types.Base64Path(existingDisk.filepath)))
+								Expect(vm.Status).To(BeEquivalentTo(types.StoppedStatus))
 								return nil
 							},
 						),
@@ -106,6 +109,15 @@ var _ = Context("resource \"freebox_virtual_machine\" { ... }", Ordered, func() 
 						Check: resource.ComposeAggregateTestCheckFunc(
 							resource.TestCheckResourceAttr("freebox_virtual_machine."+name, "name", name),
 							resource.TestCheckResourceAttr("freebox_virtual_machine."+name, "enable_cloudinit", "false"),
+							resource.TestCheckResourceAttr("freebox_virtual_machine."+name, "status", "running"),
+							func(s *terraform.State) error {
+								identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_virtual_machine."+name].Primary.Attributes["id"])
+								Expect(err).To(BeNil())
+								vm, err := freeboxClient.GetVirtualMachine(ctx, int64(identifier))
+								Expect(err).To(BeNil())
+								Expect(vm.Status).To(BeEquivalentTo(types.RunningStatus))
+								return nil
+							},
 						),
 					},
 					{
@@ -115,6 +127,7 @@ var _ = Context("resource \"freebox_virtual_machine\" { ... }", Ordered, func() 
 								memory    = 300
 								name      = "` + name + `"
 								disk_type = "qcow2"
+								status    = "stopped"
 								disk_path = "` + existingDisk.filepath + `"
 								enable_cloudinit   = true
 								cloudinit_hostname = "` + name + `"
@@ -132,6 +145,7 @@ var _ = Context("resource \"freebox_virtual_machine\" { ... }", Ordered, func() 
 							resource.TestCheckResourceAttr("freebox_virtual_machine."+name, "name", name),
 							resource.TestCheckResourceAttr("freebox_virtual_machine."+name, "enable_cloudinit", "true"),
 							resource.TestCheckResourceAttr("freebox_virtual_machine."+name, "cloudinit_hostname", name),
+							resource.TestCheckResourceAttr("freebox_virtual_machine."+name, "status", "stopped"),
 							func(s *terraform.State) error {
 								identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_virtual_machine."+name].Primary.Attributes["id"])
 								Expect(err).To(BeNil())
@@ -140,6 +154,7 @@ var _ = Context("resource \"freebox_virtual_machine\" { ... }", Ordered, func() 
 								Expect(vm.EnableCloudInit).To(BeTrue())
 								Expect(vm.CloudHostName).To(Equal(name))
 								Expect(vm.CloudInitUserData).To(MatchYAML(cloudInitConfig))
+								Expect(vm.Status).To(BeEquivalentTo(types.StoppedStatus))
 								return nil
 							},
 						),


### PR DESCRIPTION
Fixes #4.

Make the virtual machine `status` field mutable.