### PR TITLE
feat(resource/virtual_machine) Add validators

### DIFF
--- a/docs/resources/virtual_machine.md
+++ b/docs/resources/virtual_machine.md
@@ -38,8 +38,8 @@ output "ipv4" {
 
 - `bind_usb_ports` (List of String) List of ports that should be bound to this VM. Only one VM can use USB at given time, whether is uses only one or all USB ports. The list of system USB ports is available in VmSystemInfo. For example: `usb-external-type-a`, `usb-external-type-c`
 - `cd_path` (String) Path to CDROM device ISO image
-- `cloudinit_hostname` (String) When cloudinit is enabled, hostname desired for this VM. Max 59 characters
-- `cloudinit_userdata` (String) When cloudinit is enabled, raw YAML to be passed in the user-data file. Maximum 32767 characters
+- `cloudinit_hostname` (String) When cloudinit is enabled, hostname desired for this VM.
+- `cloudinit_userdata` (String) When cloudinit is enabled, raw YAML to be passed in the user-data file.
 - `enable_cloudinit` (Boolean) Whether or not to enable passing data through `cloudinit`. This uses the NoCloud iso image method; it will add a virtual CDROM drive (distinct from the one passed by `cd_path`) with the data in `cloudinit_userdata` and `cloudinit_hostname` when enabled
 - `enable_screen` (Boolean) Whether or not this VM should have a virtual screen, to use with the VNC websocket protocol
 - `os` (String) Type of OS used for this VM. Only used to set an icon for now

--- a/docs/resources/virtual_machine.md
+++ b/docs/resources/virtual_machine.md
@@ -31,7 +31,7 @@ output "ipv4" {
 - `disk_path` (String) Path to the hard disk image of this VM
 - `disk_type` (String) Type of disk image
 - `memory` (Number) Memory allocated to this VM in megabytes
-- `name` (String) Name of this VM. Max 31 characters
+- `name` (String) Name of this VM
 - `vcpus` (Number) Number of virtual CPUs to allocate to this VM
 
 ### Optional

--- a/internal/resource_virtual_machine.go
+++ b/internal/resource_virtual_machine.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -298,17 +299,28 @@ func (v *virtualMachineResource) Schema(ctx context.Context, req resource.Schema
 			"cloudinit_userdata": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
-				MarkdownDescription: "When cloudinit is enabled, raw YAML to be passed in the user-data file. Maximum 32767 characters",
+				MarkdownDescription: "When cloudinit is enabled, raw YAML to be passed in the user-data file.",
+				Validators: []validator.String{
+					stringvalidator.LengthAtMost(32767),
+				},
 			},
 			"cloudinit_hostname": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
-				MarkdownDescription: "When cloudinit is enabled, hostname desired for this VM. Max 59 characters",
+				MarkdownDescription: "When cloudinit is enabled, hostname desired for this VM.",
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 59),
+				},
 			},
 			"bind_usb_ports": schema.ListAttribute{
 				Optional:            true,
 				ElementType:         types.StringType,
 				MarkdownDescription: "List of ports that should be bound to this VM. Only one VM can use USB at given time, whether is uses only one or all USB ports. The list of system USB ports is available in VmSystemInfo. For example: `usb-external-type-a`, `usb-external-type-c`",
+				Validators: []validator.List{
+					listvalidator.ValueStringsAre(
+						stringvalidator.LengthAtLeast(1),
+					),
+				},
 			},
 			"timeouts": schema.SingleNestedAttribute{
 				MarkdownDescription: "Timeouts for various operations expressed as strings such as `30s` or `2h45m` where valid time units are `s` (seconds), `m` (minutes) and `h` (hours)",

--- a/internal/resource_virtual_machine.go
+++ b/internal/resource_virtual_machine.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -228,7 +229,10 @@ func (v *virtualMachineResource) Schema(ctx context.Context, req resource.Schema
 			},
 			"name": schema.StringAttribute{
 				Required:            true,
-				MarkdownDescription: "Name of this VM. Max 31 characters",
+				MarkdownDescription: "Name of this VM",
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 31),
+				},
 			},
 			"disk_path": schema.StringAttribute{
 				Required:            true,
@@ -238,7 +242,10 @@ func (v *virtualMachineResource) Schema(ctx context.Context, req resource.Schema
 				Required:            true,
 				MarkdownDescription: "Type of disk image",
 				Validators: []validator.String{
-					stringvalidator.OneOf([]string{freeboxTypes.QCow2Disk, freeboxTypes.RawDisk}...),
+					stringvalidator.OneOf(
+						freeboxTypes.QCow2Disk,
+						freeboxTypes.RawDisk,
+					),
 				},
 			},
 			"cd_path": schema.StringAttribute{
@@ -249,13 +256,16 @@ func (v *virtualMachineResource) Schema(ctx context.Context, req resource.Schema
 			"memory": schema.Int64Attribute{
 				Required:            true,
 				MarkdownDescription: "Memory allocated to this VM in megabytes",
+				Validators: []validator.Int64{
+					int64validator.AtLeast(1),
+				},
 			},
 			"os": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				MarkdownDescription: "Type of OS used for this VM. Only used to set an icon for now",
 				Validators: []validator.String{
-					stringvalidator.OneOf([]string{
+					stringvalidator.OneOf(
 						freeboxTypes.CentosOS,
 						freeboxTypes.DebianOS,
 						freeboxTypes.FedoraOS,
@@ -265,12 +275,15 @@ func (v *virtualMachineResource) Schema(ctx context.Context, req resource.Schema
 						freeboxTypes.OpensuseOS,
 						freeboxTypes.UbuntuOS,
 						freeboxTypes.UnknownOS,
-					}...),
+					),
 				},
 			},
 			"vcpus": schema.Int64Attribute{
 				Required:            true,
 				MarkdownDescription: "Number of virtual CPUs to allocate to this VM",
+				Validators: []validator.Int64{
+					int64validator.AtLeast(1),
+				},
 			},
 			"enable_screen": schema.BoolAttribute{
 				Optional:            true,


### PR DESCRIPTION
The goal is to add inputs validators.
sadly `tfplugindocs` does not use it to generate the readme file.
Should we add a few lines to talk about valid inputs?