### PR TITLE
Resource/remote file/move file when possible

### DIFF
--- a/docs/resources/remote_file.md
+++ b/docs/resources/remote_file.md
@@ -30,10 +30,6 @@ output "task_id" {
 - `checksum` (String) Checksum to verify the hash of the downloaded file
 - `polling` (Attributes) Polling configuration (see [below for nested schema](#nestedatt--polling))
 
-### Read-Only
-
-- `task_id` (Number) Task identifier
-
 <a id="nestedatt--authentication"></a>
 ### Nested Schema for `authentication`
 
@@ -59,13 +55,14 @@ Optional:
 - `checksum_compute` (Attributes) Checksum compute polling configuration (see [below for nested schema](#nestedatt--polling--checksum_compute))
 - `create` (Attributes) Creation polling configuration (see [below for nested schema](#nestedatt--polling--create))
 - `delete` (Attributes) Deletion polling configuration (see [below for nested schema](#nestedatt--polling--delete))
+- `move` (Attributes) Move polling configuration (see [below for nested schema](#nestedatt--polling--move))
 
 <a id="nestedatt--polling--checksum_compute"></a>
 ### Nested Schema for `polling.checksum_compute`
 
 Optional:
 
-- `interval` (String) The interval at which to poll the resource.
+- `interval` (String) The interval at which to poll.
 - `timeout` (String) The timeout for the operation.
 
 
@@ -74,7 +71,7 @@ Optional:
 
 Optional:
 
-- `interval` (String) The interval at which to poll the resource.
+- `interval` (String) The interval at which to poll.
 - `timeout` (String) The timeout for the operation.
 
 
@@ -83,7 +80,16 @@ Optional:
 
 Optional:
 
-- `interval` (String) The interval at which to poll the resource.
+- `interval` (String) The interval at which to poll.
+- `timeout` (String) The timeout for the operation.
+
+
+<a id="nestedatt--polling--move"></a>
+### Nested Schema for `polling.move`
+
+Optional:
+
+- `interval` (String) The interval at which to poll.
 - `timeout` (String) The timeout for the operation.
 
 ## Import

--- a/go.mod
+++ b/go.mod
@@ -15,9 +15,10 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/terraform-plugin-framework-timetypes v0.4.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
+	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.7.0
 	github.com/magefile/mage v1.15.0
-	github.com/nikolalohinski/free-go v1.2.0
+	github.com/nikolalohinski/free-go v1.3.1-0.20241106191455-014727852c48
 	github.com/onsi/ginkgo/v2 v2.18.0
 	github.com/onsi/gomega v1.33.1
 )
@@ -56,7 +57,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.20.0 // indirect
 	github.com/hashicorp/terraform-json v0.21.0 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.7.0
 	github.com/magefile/mage v1.15.0
-	github.com/nikolalohinski/free-go v1.3.1-0.20241106191455-014727852c48
+	github.com/nikolalohinski/free-go v1.4.0
 	github.com/onsi/ginkgo/v2 v2.18.0
 	github.com/onsi/gomega v1.33.1
 )

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo=
 github.com/muesli/termenv v0.15.2/go.mod h1:Epx+iuz8sNs7mNKhxzH4fWXGNpZwUaJKRS1noLXviQ8=
-github.com/nikolalohinski/free-go v1.2.0 h1:FQTbYpj6IXedjr+Yv3t0r/tioI33Kt3YTHx+WknwrZY=
-github.com/nikolalohinski/free-go v1.2.0/go.mod h1:x2DPbV3mIkUapqREN97kAsqQP+4QZSLNbnuxOqMJUBs=
+github.com/nikolalohinski/free-go v1.3.1-0.20241106191455-014727852c48 h1:I+pMmXyhb+OcZPvST5r5/HgB2LJSpsaQYt5iA1PYEwY=
+github.com/nikolalohinski/free-go v1.3.1-0.20241106191455-014727852c48/go.mod h1:x2DPbV3mIkUapqREN97kAsqQP+4QZSLNbnuxOqMJUBs=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/onsi/ginkgo/v2 v2.18.0 h1:W9Y7IWXxPUpAit9ieMOLI7PJZGaW22DTKgiVAuhDTLc=

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo=
 github.com/muesli/termenv v0.15.2/go.mod h1:Epx+iuz8sNs7mNKhxzH4fWXGNpZwUaJKRS1noLXviQ8=
-github.com/nikolalohinski/free-go v1.3.1-0.20241106191455-014727852c48 h1:I+pMmXyhb+OcZPvST5r5/HgB2LJSpsaQYt5iA1PYEwY=
-github.com/nikolalohinski/free-go v1.3.1-0.20241106191455-014727852c48/go.mod h1:x2DPbV3mIkUapqREN97kAsqQP+4QZSLNbnuxOqMJUBs=
+github.com/nikolalohinski/free-go v1.4.0 h1:FvKwrLTFpIEg58h5vhMOMNMfwmqaL/CgFEcSFQqIgmY=
+github.com/nikolalohinski/free-go v1.4.0/go.mod h1:x2DPbV3mIkUapqREN97kAsqQP+4QZSLNbnuxOqMJUBs=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/onsi/ginkgo/v2 v2.18.0 h1:W9Y7IWXxPUpAit9ieMOLI7PJZGaW22DTKgiVAuhDTLc=

--- a/internal/helper_test.go
+++ b/internal/helper_test.go
@@ -1,0 +1,24 @@
+package internal_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func durationEqualFunc(expected time.Duration) func(value string) error {
+	return func(strValue string) error {
+		value, err := time.ParseDuration(strValue)
+		if err != nil {
+			return fmt.Errorf("failed to parse duration: %w", err)
+		}
+		if value != expected {
+			return fmt.Errorf("expected %s, got %s", expected, value)
+		}
+
+		return nil
+	}
+}
+
+var _ resource.CheckResourceAttrWithFunc = durationEqualFunc(0)

--- a/internal/models/checksum.go
+++ b/internal/models/checksum.go
@@ -1,0 +1,59 @@
+package models
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	freeboxTypes "github.com/nikolalohinski/free-go/types"
+)
+
+func ChecksumValidator() validator.String {
+	return &checksumValidator{
+		methodValidator: stringvalidator.OneOf(
+			string(freeboxTypes.HashTypeMD5),
+			string(freeboxTypes.HashTypeSHA1),
+			string(freeboxTypes.HashTypeSHA256),
+			string(freeboxTypes.HashTypeSHA512),
+		),
+		valueValidator: stringvalidator.LengthAtLeast(1),
+	}
+}
+
+type checksumValidator struct{
+	methodValidator validator.String
+	valueValidator  validator.String
+}
+
+func (s *checksumValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	parts := strings.SplitN(req.ConfigValue.ValueString(), ":", 2)
+	if len(parts) != 2 {
+		// Use the default hash function
+		return
+	}
+
+	s.methodValidator.ValidateString(ctx, validator.StringRequest{
+		Path: req.Path.AtTupleIndex(0),
+		PathExpression: req.PathExpression.AtSetValue(basetypes.NewStringValue(parts[0])),
+		ConfigValue: basetypes.NewStringValue(parts[0]),
+		Config: req.Config,
+	}, resp)
+	s.valueValidator.ValidateString(ctx, validator.StringRequest{
+		Path: req.Path.AtTupleIndex(1),
+		PathExpression: req.PathExpression.AtSetValue(basetypes.NewStringValue(parts[1])),
+		ConfigValue: basetypes.NewStringValue(parts[1]),
+		Config: req.Config,
+	}, resp)
+
+	return
+}
+
+func (s *checksumValidator) Description(ctx context.Context) string {
+	return "Checksum validator"
+}
+
+func (s *checksumValidator) MarkdownDescription(ctx context.Context) string {
+	return "Checksum validator"
+}

--- a/internal/models/download_url.go
+++ b/internal/models/download_url.go
@@ -1,0 +1,44 @@
+package models
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+func DownloadURLValidator() validator.String {
+	return &downloadURLValidator{
+		schemeValidator: stringvalidator.OneOf("http", "https", "ftp", "magnet"),
+	}
+}
+
+type downloadURLValidator struct{
+	schemeValidator validator.String
+}
+
+
+func (s *downloadURLValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	u, err := url.Parse(req.ConfigValue.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid URL", err.Error())
+		return
+	}
+
+	s.schemeValidator.ValidateString(ctx, validator.StringRequest{
+		Path: req.Path.AtName("scheme"),
+		PathExpression: req.PathExpression.AtName("scheme"),
+		ConfigValue: basetypes.NewStringValue(u.Scheme),
+		Config: req.Config,
+	}, resp)
+}
+
+func (s *downloadURLValidator) Description(ctx context.Context) string {
+	return "Download URL validator"
+}
+
+func (s *downloadURLValidator) MarkdownDescription(ctx context.Context) string {
+	return "Download URL validator"
+}

--- a/internal/models/file_path.go
+++ b/internal/models/file_path.go
@@ -1,0 +1,28 @@
+package models
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+func FilePathValidator() validator.String {
+	return &filePathValidator{}
+}
+
+type filePathValidator struct{}
+
+func (s *filePathValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	stringvalidator.LengthAtLeast(1).ValidateString(ctx, req, resp)
+
+	return
+}
+
+func (s *filePathValidator) Description(ctx context.Context) string {
+	return "File path validator"
+}
+
+func (s *filePathValidator) MarkdownDescription(ctx context.Context) string {
+	return "File path validator"
+}

--- a/internal/models/polling.go
+++ b/internal/models/polling.go
@@ -1,0 +1,54 @@
+package models
+
+import (
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+
+type Polling struct {
+	Interval timetypes.GoDuration `tfsdk:"interval"`
+	Timeout  timetypes.GoDuration `tfsdk:"timeout"`
+}
+
+func NewPollingSpecModel(interval, timeout time.Duration) basetypes.ObjectValue {
+	return basetypes.NewObjectValueMust(Polling{}.AttrTypes(), map[string]attr.Value{
+		"interval": timetypes.NewGoDurationValue(interval),
+		"timeout":  timetypes.NewGoDurationValue(timeout),
+	})
+}
+
+func PollingSpecModelResourceAttributes(interval, timeout time.Duration) map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"interval": schema.StringAttribute{
+			Optional:            true,
+			Computed:            true,
+			CustomType:          timetypes.GoDurationType{},
+			MarkdownDescription: "The interval at which to poll.",
+			Default: 		     stringdefault.StaticString(timetypes.NewGoDurationValue(interval).String()),
+		},
+		"timeout": schema.StringAttribute{
+			Optional:            true,
+			Computed:            true,
+			CustomType:          timetypes.GoDurationType{},
+			MarkdownDescription: "The timeout for the operation.",
+			Default: 		     stringdefault.StaticString(timetypes.NewGoDurationValue(timeout).String()),
+		},
+	}
+}
+
+func (o Polling) ResourceAttributes() map[string]schema.Attribute {
+	return PollingSpecModelResourceAttributes(5*time.Second, 5*time.Minute)
+}
+
+func (o Polling) AttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"interval": timetypes.GoDurationType{},
+		"timeout":  timetypes.GoDurationType{},
+	}
+}

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -1,0 +1,64 @@
+package models
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type Task struct {
+	ID   types.Int64  `tfsdk:"id"`
+	Type types.String `tfsdk:"type"`
+}
+
+func (o Task) ResourceAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"id": schema.Int64Attribute{
+			Computed:            true,
+			MarkdownDescription: "The task ID.",
+			Validators: []validator.Int64{
+				int64validator.AtLeast(0),
+			},
+			PlanModifiers: []planmodifier.Int64{
+				int64planmodifier.UseStateForUnknown(),
+			},
+		},
+		"type": schema.StringAttribute{
+			Computed:            true,
+			MarkdownDescription: "The task type.",
+			Validators: []validator.String{
+				TaskTypeValidator(),
+			},
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
+	}
+}
+
+func (o Task) AttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":   types.Int64Type,
+		"type": types.StringType,
+	}
+}
+
+func TaskTypeValidator() validator.String {
+	return stringvalidator.OneOf(
+		string(TaskTypeDownload),
+		string(TaskTypeFileSystem),
+	)
+}
+
+type TaskType string
+
+const (
+	TaskTypeDownload    TaskType = "download"
+	TaskTypeFileSystem  TaskType = "file_system"
+)

--- a/internal/provider_data/current_task.go
+++ b/internal/provider_data/current_task.go
@@ -1,0 +1,53 @@
+package providerdata
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/nikolalohinski/terraform-provider-freebox/internal/models"
+)
+
+const taskKey = "task"
+
+func UnsetCurrentTask(ctx context.Context, state Setter) (diagnotics diag.Diagnostics) {
+	return state.SetKey(ctx, taskKey, nil)
+}
+
+func SetCurrentTask(ctx context.Context, state Setter, taskType models.TaskType, id int64) (diagnotics diag.Diagnostics) {
+	taskBytes, err := json.Marshal(&models.Task{
+		ID:   basetypes.NewInt64Value(id),
+		Type: basetypes.NewStringValue(string(taskType)),
+	})
+	if err != nil {
+		diagnotics.AddError("Failed to marshal task", fmt.Sprintf("Task: %d, Type: %s, Errorf: %v", id, taskType, err))
+		return
+	}
+
+	return state.SetKey(ctx, taskKey, taskBytes)
+}
+
+func GetCurrentTask(ctx context.Context, state Getter) (task *models.Task, diagnotics diag.Diagnostics) {
+	taskBytes, diags := state.GetKey(ctx, taskKey)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	if len(taskBytes) == 0 {
+		return nil, nil
+	}
+
+	task = new(models.Task)
+	if err := json.Unmarshal(taskBytes, task); err != nil {
+		diagnotics.AddError("Failed to unmarshal task", fmt.Sprintf("Task: %s, Error: %v", string(taskBytes), err))
+		return nil, diagnotics
+	}
+
+	if task.ID.IsNull() || task.ID.Equal(basetypes.NewInt64Value(0)) {
+		return nil, nil
+	}
+
+	return task, nil
+}

--- a/internal/provider_data/provider_data.go
+++ b/internal/provider_data/provider_data.go
@@ -1,0 +1,16 @@
+package providerdata
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+
+type Setter interface {
+	SetKey(ctx context.Context, key string, value []byte) diag.Diagnostics
+}
+
+type Getter interface {
+	GetKey(ctx context.Context, key string) ([]byte, diag.Diagnostics)
+}

--- a/internal/resource_remote_file.go
+++ b/internal/resource_remote_file.go
@@ -669,7 +669,7 @@ func (v *remoteFileResource) Update(ctx context.Context, req resource.UpdateRequ
 
 		tflog.Debug(ctx, "Moving the file...")
 
-		task, err := v.client.MoveFile(ctx, oldModel.DestinationPath.ValueString(), newModel.DestinationPath.ValueString(), freeboxTypes.FileMoveModeOverwrite)
+		task, err := v.client.MoveFiles(ctx, []string{oldModel.DestinationPath.ValueString()}, newModel.DestinationPath.ValueString(), freeboxTypes.FileMoveModeOverwrite)
 		if err != nil {
 			resp.Diagnostics.AddError("Failed to move file", fmt.Sprintf("From: %s, To: %s, Error: %s", oldModel.DestinationPath.ValueString(), newModel.DestinationPath.ValueString(), err.Error()))
 			return

--- a/internal/resource_remote_file_test.go
+++ b/internal/resource_remote_file_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nikolalohinski/free-go/client"
 	"github.com/nikolalohinski/free-go/types"
+	"github.com/nikolalohinski/terraform-provider-freebox/internal"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -18,7 +19,7 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 )
 
-var _ = Context(`resource "freebox_remote_file" { ... }`, func() {
+var _ = FContext(`resource "freebox_remote_file" { ... }`, func() {
 	var (
 		exampleFile  file
 		resourceName string
@@ -68,20 +69,20 @@ var _ = Context(`resource "freebox_remote_file" { ... }`, func() {
 								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "source_url", exampleFile.source),
 								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "destination_path", exampleFile.filepath),
 								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "checksum", exampleFile.digest),
-								resource.TestCheckResourceAttrWith("freebox_remote_file."+resourceName, "task_id", func(value string) error {
+								resource.TestCheckResourceAttrWith("freebox_remote_file."+resourceName, "task.id", func(value string) error {
 									taskID, err := strconv.Atoi(value)
 									if err != nil {
 										return err
 									}
 
 									if taskID == 0 {
-										return fmt.Errorf("task_id is not set")
+										return fmt.Errorf("task.id is not set")
 									}
 
 									return nil
 								}),
 								func(s *terraform.State) error {
-									identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task_id"])
+									identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task.id"])
 									Expect(err).To(BeNil())
 									task, err := freeboxClient.GetDownloadTask(ctx, int64(identifier))
 									Expect(err).To(BeNil())
@@ -98,7 +99,7 @@ var _ = Context(`resource "freebox_remote_file" { ... }`, func() {
 						},
 					},
 					CheckDestroy: func(s *terraform.State) error {
-						identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task_id"])
+						identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task.id"])
 						Expect(err).To(BeNil())
 						Expect(identifier).ToNot(BeZero())
 
@@ -133,7 +134,7 @@ var _ = Context(`resource "freebox_remote_file" { ... }`, func() {
 								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "polling.delete.interval", "1s"),
 								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "polling.delete.timeout", "1m"),
 								func(s *terraform.State) error {
-									identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task_id"])
+									identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task.id"])
 									Expect(err).To(BeNil())
 									task, err := freeboxClient.GetDownloadTask(ctx, int64(identifier))
 									Expect(err).To(BeNil())
@@ -150,7 +151,7 @@ var _ = Context(`resource "freebox_remote_file" { ... }`, func() {
 						},
 					},
 					CheckDestroy: func(s *terraform.State) error {
-						identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task_id"])
+						identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task.id"])
 						Expect(err).To(BeNil())
 						Expect(identifier).ToNot(BeZero())
 
@@ -194,7 +195,7 @@ var _ = Context(`resource "freebox_remote_file" { ... }`, func() {
 									resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "polling.checksum_compute.interval", "1s"),
 									resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "polling.checksum_compute.timeout", "1m"),
 									func(s *terraform.State) error {
-										identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task_id"])
+										identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task.id"])
 										Expect(err).To(BeNil())
 										task, err := freeboxClient.GetDownloadTask(ctx, int64(identifier))
 										Expect(err).To(BeNil())
@@ -211,7 +212,7 @@ var _ = Context(`resource "freebox_remote_file" { ... }`, func() {
 							},
 						},
 						CheckDestroy: func(s *terraform.State) error {
-							identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task_id"])
+							identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task.id"])
 							Expect(err).To(BeNil())
 							Expect(identifier).ToNot(BeZero())
 
@@ -255,24 +256,25 @@ var _ = Context(`resource "freebox_remote_file" { ... }`, func() {
 									}
 								}
 							`,
+
 							Check: resource.ComposeAggregateTestCheckFunc(
 								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "source_url", exampleFile.source),
 								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "destination_path", exampleFile.filepath),
 								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "checksum", exampleFile.digest),
-								resource.TestCheckResourceAttrWith("freebox_remote_file."+resourceName, "task_id", func(value string) error {
+								resource.TestCheckResourceAttrWith("freebox_remote_file."+resourceName, "task.id", func(value string) error {
 									taskID, err := strconv.Atoi(value)
 									if err != nil {
 										return err
 									}
 
 									if taskID == 0 {
-										return fmt.Errorf("task_id is not set")
+										return fmt.Errorf("task.id is not set")
 									}
 
 									return nil
 								}),
 								func(s *terraform.State) error {
-									identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task_id"])
+									identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task.id"])
 									Expect(err).To(BeNil())
 									task, err := freeboxClient.GetDownloadTask(ctx, int64(identifier))
 									Expect(err).To(BeNil())
@@ -289,7 +291,7 @@ var _ = Context(`resource "freebox_remote_file" { ... }`, func() {
 						},
 					},
 					CheckDestroy: func(s *terraform.State) error {
-						identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task_id"])
+						identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task.id"])
 						Expect(err).To(BeNil())
 						Expect(identifier).ToNot(BeZero())
 
@@ -341,121 +343,245 @@ var _ = Context(`resource "freebox_remote_file" { ... }`, func() {
 	})
 
 	Context("create, update and delete (CUD)", func() {
-		It("should create, update and finally delete a file", func(ctx SpecContext) {
-			resource.UnitTest(GinkgoT(), resource.TestCase{
-				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-				Steps: []resource.TestStep{
-					{
-						Config: providerBlock + `
-							resource "freebox_remote_file" "` + resourceName + `" {
-								source_url = "` + exampleFile.source + `"
-								destination_path = "` + exampleFile.filepath + `"
-								checksum = "` + exampleFile.digest + `"
+		Context("when only path change", func() {
+			It("should create, move and finally delete a file", func(ctx SpecContext) {
+				resource.UnitTest(GinkgoT(), resource.TestCase{
+					ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+					Steps: []resource.TestStep{
+						{
+							Config: providerBlock + `
+								resource "freebox_remote_file" "` + resourceName + `" {
+									source_url = "` + exampleFile.source + `"
+									destination_path = "` + exampleFile.filepath + `"
+									checksum = "` + exampleFile.digest + `"
 
-								polling = {
-									create = {
-										interval = "1s"
-										timeout = "1m"
-									}
-									delete = {
-										interval = "1s"
-										timeout = "1m"
-									}
-									checksum_compute = {
-										interval = "1s"
-										timeout = "1m"
+									polling = {
+										create = {
+											interval = "1s"
+											timeout = "1m"
+										}
+										delete = {
+											interval = "1s"
+											timeout = "1m"
+										}
+										checksum_compute = {
+											interval = "1s"
+											timeout = "1m"
+										}
 									}
 								}
-							}
-						`,
-						Check: resource.ComposeAggregateTestCheckFunc(
-							resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "checksum", exampleFile.digest),
-							resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "destination_path", exampleFile.filepath),
-							resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "source_url", exampleFile.source),
-							func(s *terraform.State) error {
-								identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task_id"])
-								Expect(err).To(BeNil())
-								task, err := freeboxClient.GetDownloadTask(ctx, int64(identifier))
-								Expect(err).To(BeNil())
-								Expect(task.Name).To(Equal(exampleFile.filename))
-								Expect(task.Status).To(BeEquivalentTo(types.DownloadTaskStatusDone))
+							`,
+							Check: resource.ComposeAggregateTestCheckFunc(
+								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "checksum", exampleFile.digest),
+								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "destination_path", exampleFile.filepath),
+								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "source_url", exampleFile.source),
+								func(s *terraform.State) error {
+									identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task.id"])
+									Expect(err).To(BeNil())
+									task, err := freeboxClient.GetDownloadTask(ctx, int64(identifier))
+									Expect(err).To(BeNil())
+									Expect(task.Name).To(Equal(exampleFile.filename))
+									Expect(task.Status).To(BeEquivalentTo(types.DownloadTaskStatusDone))
 
-								fileInfo, err := freeboxClient.GetFileInfo(ctx, exampleFile.filepath)
-								Expect(err).To(BeNil())
-								Expect(fileInfo.Name).To(Equal(exampleFile.filename))
-								Expect(fileInfo.Type).To(BeEquivalentTo(types.FileTypeFile))
-								return nil
-							},
-						),
-					},
-					{
-						Config: providerBlock + `
-							resource "freebox_remote_file" "` + resourceName + `" {
-								source_url = "` + exampleFile.source + `"
-								destination_path = "` + exampleFile.filepath + `.new"
-								checksum = "` + exampleFile.digest + `"
-
-								polling = {
-									create = {
-										interval = "1s"
-										timeout = "1m"
-									}
-									delete = {
-										interval = "1s"
-										timeout = "1m"
-									}
-									checksum_compute = {
-										interval = "1s"
-										timeout = "1m"
-									}
-								}
-							}
-						`,
-						ConfigPlanChecks: resource.ConfigPlanChecks{
-							PreApply: []plancheck.PlanCheck{
-								plancheck.ExpectResourceAction("freebox_remote_file."+resourceName, plancheck.ResourceActionUpdate),
-							},
+									fileInfo, err := freeboxClient.GetFileInfo(ctx, exampleFile.filepath)
+									Expect(err).To(BeNil())
+									Expect(fileInfo.Name).To(Equal(exampleFile.filename))
+									Expect(fileInfo.Type).To(BeEquivalentTo(types.FileTypeFile))
+									return nil
+								},
+							),
 						},
-						Check: resource.ComposeAggregateTestCheckFunc(
-							resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "checksum", exampleFile.digest),
-							resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "destination_path", exampleFile.filepath+".new"),
-							resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "source_url", exampleFile.source),
-							func(s *terraform.State) error {
-								_, err := freeboxClient.GetFileInfo(ctx, exampleFile.filepath)
-								Expect(err).To(MatchError(client.ErrPathNotFound), "file %s should no more exist", exampleFile.filepath)
+						{
+							Config: providerBlock + `
+								resource "freebox_remote_file" "` + resourceName + `" {
+									source_url = "` + exampleFile.source + `"
+									destination_path = "` + exampleFile.filepath + `.new"
+									checksum = "` + exampleFile.digest + `"
 
-								identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task_id"])
-								Expect(err).To(BeNil())
-								task, err := freeboxClient.GetDownloadTask(ctx, int64(identifier))
-								Expect(err).To(BeNil())
-								Expect(task.Name).To(Equal(exampleFile.filename + ".new"))
-								Expect(task.Status).To(BeEquivalentTo(types.DownloadTaskStatusDone))
-
-								fileInfo, err := freeboxClient.GetFileInfo(ctx, exampleFile.filepath+".new")
-								Expect(err).To(BeNil())
-								Expect(fileInfo.Name).To(Equal(exampleFile.filename + ".new"))
-								Expect(fileInfo.Type).To(BeEquivalentTo(types.FileTypeFile))
-								return nil
+									polling = {
+										create = {
+											interval = "1s"
+											timeout = "1m"
+										}
+										delete = {
+											interval = "1s"
+											timeout = "1m"
+										}
+										checksum_compute = {
+											interval = "1s"
+											timeout = "1m"
+										}
+									}
+								}
+							`,
+							ConfigPlanChecks: resource.ConfigPlanChecks{
+								PreApply: []plancheck.PlanCheck{
+									plancheck.ExpectResourceAction("freebox_remote_file."+resourceName, plancheck.ResourceActionUpdate),
+								},
 							},
-						),
+							Check: resource.ComposeAggregateTestCheckFunc(
+								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "checksum", exampleFile.digest),
+								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "destination_path", exampleFile.filepath+".new"),
+								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "source_url", exampleFile.source),
+								func(s *terraform.State) error {
+									_, err := freeboxClient.GetFileInfo(ctx, exampleFile.filepath)
+									Expect(err).To(MatchError(client.ErrPathNotFound), "file %s should no more exist", exampleFile.filepath)
+
+									taskType := s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task.type"]
+									Expect(taskType).To(BeEquivalentTo(internal.TaskTypeFileSystem))
+									taskID, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task.id"])
+									Expect(err).To(BeNil())
+									task, err := freeboxClient.GetFileSystemTask(ctx, int64(taskID))
+									Expect(err).To(BeNil())
+									Expect(task.Destination).To(Equal(exampleFile.filepath + ".new"))
+									Expect(task.State).To(BeEquivalentTo(types.FileTaskStateDone))
+
+									fileInfo, err := freeboxClient.GetFileInfo(ctx, exampleFile.filepath+".new")
+									Expect(err).To(BeNil())
+									Expect(fileInfo.Name).To(Equal(exampleFile.filename + ".new"))
+									Expect(fileInfo.Type).To(BeEquivalentTo(types.FileTypeFile))
+									return nil
+								},
+							),
+						},
 					},
-				},
-				CheckDestroy: func(s *terraform.State) error {
-					identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task_id"])
-					Expect(err).To(BeNil())
-					Expect(identifier).ToNot(BeZero())
+					CheckDestroy: func(s *terraform.State) error {
+						identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task.id"])
+						Expect(err).To(BeNil())
+						Expect(identifier).ToNot(BeZero())
 
-					_, err = freeboxClient.GetDownloadTask(ctx, int64(identifier))
-					Expect(err).To(MatchError(client.ErrTaskNotFound))
+						_, err = freeboxClient.GetDownloadTask(ctx, int64(identifier))
+						Expect(err).To(MatchError(client.ErrTaskNotFound))
 
-					_, err = freeboxClient.GetFileInfo(ctx, exampleFile.filepath)
-					Expect(err).To(MatchError(client.ErrPathNotFound), "file %s should not exist", exampleFile.filepath)
+						_, err = freeboxClient.GetFileInfo(ctx, exampleFile.filepath)
+						Expect(err).To(MatchError(client.ErrPathNotFound), "file %s should not exist", exampleFile.filepath)
 
-					_, err = freeboxClient.GetFileInfo(ctx, exampleFile.filepath+".new")
-					Expect(err).To(MatchError(client.ErrPathNotFound), "file %s should not exist", exampleFile.filepath+".new")
+						_, err = freeboxClient.GetFileInfo(ctx, exampleFile.filepath+".new")
+						Expect(err).To(MatchError(client.ErrPathNotFound), "file %s should not exist", exampleFile.filepath+".new")
 
-					return nil
-				},
+						return nil
+					},
+				})
+			})
+		})
+		Context("when the file to download change", func() {
+			FIt("should create, move and finally delete a file", func(ctx SpecContext) {
+				resource.UnitTest(GinkgoT(), resource.TestCase{
+					ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+					Steps: []resource.TestStep{
+						{
+							Config: providerBlock + `
+								resource "freebox_remote_file" "` + resourceName + `" {
+									source_url = "` + exampleFile.source + `"
+									destination_path = "` + exampleFile.filepath + `"
+									checksum = "` + exampleFile.digest + `"
+
+									polling = {
+										create = {
+											interval = "1s"
+											timeout = "1m"
+										}
+										delete = {
+											interval = "1s"
+											timeout = "1m"
+										}
+										checksum_compute = {
+											interval = "1s"
+											timeout = "1m"
+										}
+									}
+								}
+							`,
+							Check: resource.ComposeAggregateTestCheckFunc(
+								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "checksum", exampleFile.digest),
+								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "destination_path", exampleFile.filepath),
+								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "source_url", exampleFile.source),
+								func(s *terraform.State) error {
+									identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task.id"])
+									Expect(err).To(BeNil())
+									task, err := freeboxClient.GetDownloadTask(ctx, int64(identifier))
+									Expect(err).To(BeNil())
+									Expect(task.Name).To(Equal(exampleFile.filename))
+									Expect(task.Status).To(BeEquivalentTo(types.DownloadTaskStatusDone))
+
+									fileInfo, err := freeboxClient.GetFileInfo(ctx, exampleFile.filepath)
+									Expect(err).To(BeNil())
+									Expect(fileInfo.Name).To(Equal(exampleFile.filename))
+									Expect(fileInfo.Type).To(BeEquivalentTo(types.FileTypeFile))
+									return nil
+								},
+							),
+						},
+						{
+							Config: providerBlock + `
+								resource "freebox_remote_file" "` + resourceName + `" {
+									source_url = "` + exampleFile.source + `#new"
+									destination_path = "` + exampleFile.filepath + `"
+
+									polling = {
+										create = {
+											interval = "1s"
+											timeout = "1m"
+										}
+										delete = {
+											interval = "1s"
+											timeout = "1m"
+										}
+										checksum_compute = {
+											interval = "1s"
+											timeout = "1m"
+										}
+									}
+								}
+							`,
+							ConfigPlanChecks: resource.ConfigPlanChecks{
+								PreApply: []plancheck.PlanCheck{
+									plancheck.ExpectResourceAction("freebox_remote_file."+resourceName, plancheck.ResourceActionReplace),
+								},
+							},
+							Check: resource.ComposeAggregateTestCheckFunc(
+								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "checksum", exampleFile.digest),
+								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "destination_path", exampleFile.filepath+".new"),
+								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "source_url", exampleFile.source),
+								func(s *terraform.State) error {
+									_, err := freeboxClient.GetFileInfo(ctx, exampleFile.filepath)
+									Expect(err).To(MatchError(client.ErrPathNotFound), "file %s should no more exist", exampleFile.filepath)
+
+									taskType := s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task.type"]
+									Expect(taskType).To(BeEquivalentTo(internal.TaskTypeFileSystem))
+									taskID, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task.id"])
+									Expect(err).To(BeNil())
+									task, err := freeboxClient.GetFileSystemTask(ctx, int64(taskID))
+									Expect(err).To(BeNil())
+									Expect(task.Destination).To(Equal(exampleFile.filepath + ".new"))
+									Expect(task.State).To(BeEquivalentTo(types.FileTaskStateDone))
+
+									fileInfo, err := freeboxClient.GetFileInfo(ctx, exampleFile.filepath+".new")
+									Expect(err).To(BeNil())
+									Expect(fileInfo.Name).To(Equal(exampleFile.filename + ".new"))
+									Expect(fileInfo.Type).To(BeEquivalentTo(types.FileTypeFile))
+									return nil
+								},
+							),
+						},
+					},
+					CheckDestroy: func(s *terraform.State) error {
+						identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task.id"])
+						Expect(err).To(BeNil())
+						Expect(identifier).ToNot(BeZero())
+
+						_, err = freeboxClient.GetDownloadTask(ctx, int64(identifier))
+						Expect(err).To(MatchError(client.ErrTaskNotFound))
+
+						_, err = freeboxClient.GetFileInfo(ctx, exampleFile.filepath)
+						Expect(err).To(MatchError(client.ErrPathNotFound), "file %s should not exist", exampleFile.filepath)
+
+						_, err = freeboxClient.GetFileInfo(ctx, exampleFile.filepath+".new")
+						Expect(err).To(MatchError(client.ErrPathNotFound), "file %s should not exist", exampleFile.filepath+".new")
+
+						return nil
+					},
+				})
 			})
 		})
 		Context("when only the task changed", func() {
@@ -491,7 +617,7 @@ var _ = Context(`resource "freebox_remote_file" { ... }`, func() {
 								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "destination_path", exampleFile.filepath),
 								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "source_url", exampleFile.source),
 								func(s *terraform.State) error {
-									identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task_id"])
+									identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task.id"])
 									Expect(err).To(BeNil())
 									task, err := freeboxClient.GetDownloadTask(ctx, int64(identifier))
 									Expect(err).To(BeNil())
@@ -512,7 +638,7 @@ var _ = Context(`resource "freebox_remote_file" { ... }`, func() {
 									source_url = "` + exampleFile.source + `"
 									destination_path = "` + exampleFile.filepath + `"
 									checksum = "` + exampleFile.digest + `"
-									task_id = null
+									task = null
 
 									polling = {
 										create = {
@@ -540,7 +666,7 @@ var _ = Context(`resource "freebox_remote_file" { ... }`, func() {
 								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "destination_path", exampleFile.filepath),
 								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "source_url", exampleFile.source),
 								func(s *terraform.State) error {
-									identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task_id"])
+									identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task.id"])
 									Expect(err).To(BeNil())
 									task, err := freeboxClient.GetDownloadTask(ctx, int64(identifier))
 									Expect(err).To(BeNil())
@@ -557,7 +683,7 @@ var _ = Context(`resource "freebox_remote_file" { ... }`, func() {
 						},
 					},
 					CheckDestroy: func(s *terraform.State) error {
-						identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task_id"])
+						identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task.id"])
 						Expect(err).To(BeNil())
 						Expect(identifier).ToNot(BeZero())
 
@@ -636,13 +762,13 @@ var _ = Context(`resource "freebox_remote_file" { ... }`, func() {
 								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "checksum", exampleFile.digest),
 								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "destination_path", exampleFile.filepath),
 								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "source_url", exampleFile.source),
-								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "task_id", strconv.Itoa(int(remoteFileTaskID))),
+								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "task.id", strconv.Itoa(int(remoteFileTaskID))),
 							),
 							Destroy: true,
 						},
 					},
 					CheckDestroy: func(s *terraform.State) error {
-						identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task_id"])
+						identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task.id"])
 						Expect(err).To(BeNil())
 						Expect(identifier).ToNot(BeZero())
 
@@ -693,13 +819,13 @@ var _ = Context(`resource "freebox_remote_file" { ... }`, func() {
 								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "checksum", exampleFile.digest),
 								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "destination_path", exampleFile.filepath),
 								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "source_url", exampleFile.source),
-								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "task_id", strconv.Itoa(int(remoteFileTaskID))),
+								resource.TestCheckResourceAttr("freebox_remote_file."+resourceName, "task.id", strconv.Itoa(int(remoteFileTaskID))),
 							),
 							Destroy: true,
 						},
 					},
 					CheckDestroy: func(s *terraform.State) error {
-						identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task_id"])
+						identifier, err := strconv.Atoi(s.RootModule().Resources["freebox_remote_file."+resourceName].Primary.Attributes["task.id"])
 						Expect(err).To(BeNil())
 						Expect(identifier).ToNot(BeZero())
 


### PR DESCRIPTION
Hello @NikolaLohinski,

I re-worked (a lot) the `remote_file` resource:

- [x] Current task is now private and no more part of the resource output.
- [x] Delete the task as soon as it is completed.
- [x] Keep the task on error.
- [x] Move the file when possible (instead of download it every time).
- [x] Indicate in the plan when the resource will be replaced (downloaded and not only moved).
- [x] Introduce the `models` package to share types between resources or data sources.
- [x] Add log entries for debugging purpose.
- [x] Add tests to `remote_file` resource to cover more use cases.
- [x] Add checks to test to ensure the provider does not leave tasks after applying.

I know the PR is big, I suggest you to review the new file without trying to map to the old code.