### PR TITLE
fix(resource/virtual_disk) Introduce Create polling attribute

### DIFF
--- a/docs/resources/virtual_disk.md
+++ b/docs/resources/virtual_disk.md
@@ -38,8 +38,18 @@ output "task_id" {
 
 Optional:
 
+- `create` (Attributes) Polling configuration for create operation (see [below for nested schema](#nestedatt--polling--create))
 - `delete` (Attributes) Polling configuration for delete operation (see [below for nested schema](#nestedatt--polling--delete))
 - `move` (Attributes) Polling configuration for move operation (see [below for nested schema](#nestedatt--polling--move))
+
+<a id="nestedatt--polling--create"></a>
+### Nested Schema for `polling.create`
+
+Optional:
+
+- `interval` (String) The interval at which to poll.
+- `timeout` (String) The timeout for the operation.
+
 
 <a id="nestedatt--polling--delete"></a>
 ### Nested Schema for `polling.delete`

--- a/internal/resource_virtual_disk.go
+++ b/internal/resource_virtual_disk.go
@@ -82,6 +82,8 @@ func (v *virtualDiskModel) toResizePayload() (payload freeboxTypes.VirtualDisksR
 }
 
 type virtualDiskPollingModel struct {
+	// Create is the polling configuration for create operation.
+	Create types.Object `tfsdk:"create"`
 	// Delete is the polling configuration for delete operation.
 	Delete types.Object `tfsdk:"delete"`
 	// Move is the polling configuration for move operation.
@@ -90,6 +92,7 @@ type virtualDiskPollingModel struct {
 
 func (v virtualDiskPollingModel) defaults() basetypes.ObjectValue {
 	return basetypes.NewObjectValueMust(virtualDiskPollingModel{}.AttrTypes(), map[string]attr.Value{
+		"create": models.NewPollingSpecModel(time.Second, time.Minute),
 		"delete": models.NewPollingSpecModel(time.Second, time.Minute),
 		"move":   models.NewPollingSpecModel(time.Second, time.Minute),
 	})
@@ -97,6 +100,13 @@ func (v virtualDiskPollingModel) defaults() basetypes.ObjectValue {
 
 func (v virtualDiskPollingModel) ResourceAttributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
+		"create": schema.SingleNestedAttribute{
+			Optional:            true,
+			Computed:            true,
+			MarkdownDescription: "Polling configuration for create operation",
+			Attributes:          models.PollingSpecModelResourceAttributes(time.Second, time.Minute),
+			Default:             objectdefault.StaticValue(models.NewPollingSpecModel(time.Second, time.Minute)),
+		},
 		"delete": schema.SingleNestedAttribute{
 			Optional:            true,
 			Computed:            true,
@@ -116,6 +126,7 @@ func (v virtualDiskPollingModel) ResourceAttributes() map[string]schema.Attribut
 
 func (v virtualDiskPollingModel) AttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
+		"create": types.ObjectType{}.WithAttributeTypes(models.Polling{}.AttrTypes()),
 		"move":   types.ObjectType{}.WithAttributeTypes(models.Polling{}.AttrTypes()),
 		"delete": types.ObjectType{}.WithAttributeTypes(models.Polling{}.AttrTypes()),
 	}
@@ -281,7 +292,7 @@ func (v *virtualDiskResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 	if task != nil {
-		var pollingModel remoteFilePollingModel
+		var pollingModel virtualDiskPollingModel
 		if diags := oldModel.Polling.As(ctx, &pollingModel, basetypes.ObjectAsOptions{}); diags.HasError() {
 			resp.Diagnostics.Append(diags...)
 			return


### PR DESCRIPTION
Before, the `virtual_disk` resource was using the default polling value from `remoteFilePollingModel.Create`.

This PR aims to adds the `Create` attribute dedicated to virtual_disk resource.