### PR TITLE
fix(tests) Fail gracefully when the `FREEBOX_TOKEN` is missing

### DIFF
--- a/internal/suite_test.go
+++ b/internal/suite_test.go
@@ -55,10 +55,10 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 	if !ok {
 		appID = "terraform-provider-freebox"
 	}
+
 	token, ok = os.LookupEnv("FREEBOX_TOKEN")
-	if !ok {
-		panic("FREEBOX_TOKEN environment variable is not set")
-	}
+	Expect(ok).To(BeTrue(), "FREEBOX_TOKEN environment variable is not set")
+
 	providerBlock = heredoc.Doc(`
 		provider "freebox" {
 			app_id = "` + appID + `"


### PR DESCRIPTION
The current `panic` statement is rough.
We should use the `gomega` helpers to check errors.