### PR TITLE
docs(vpn): add example files for freebox_vpn_server and freebox_vpn_user

### DIFF
--- a/examples/import.freebox_vpn_server.sh
+++ b/examples/import.freebox_vpn_server.sh
@@ -1,0 +1,2 @@
+# The VPN server is a singleton resource; use "openvpn" as the import ID
+terraform import "freebox_vpn_server.example" openvpn

--- a/examples/import.freebox_vpn_user.sh
+++ b/examples/import.freebox_vpn_user.sh
@@ -1,0 +1,2 @@
+# ----------------------------------------- 👇 is the login of the VPN user
+terraform import "freebox_vpn_user.example" myuser

--- a/examples/resource.freebox_vpn_server.tf
+++ b/examples/resource.freebox_vpn_server.tf
@@ -1,0 +1,4 @@
+resource "freebox_vpn_server" "example" {
+  enabled     = true
+  server_port = 1194
+}

--- a/examples/resource.freebox_vpn_user.tf
+++ b/examples/resource.freebox_vpn_user.tf
@@ -1,0 +1,10 @@
+resource "freebox_vpn_user" "example" {
+  login       = "myuser"
+  password    = "s3cr3t"
+  description = "Example VPN user"
+}
+
+output "ovpn_config" {
+  value     = freebox_vpn_user.example.ovpn_config
+  sensitive = true
+}


### PR DESCRIPTION
## Summary

- Adds `examples/resource.freebox_vpn_server.tf`
- Adds `examples/resource.freebox_vpn_user.tf`
- Adds `examples/import.freebox_vpn_server.sh`
- Adds `examples/import.freebox_vpn_user.sh`

Fixes the missing example files that prevented `mage docs/build` from completing (as noted in NikolaLohinski/terraform-provider-freebox#48 (comment)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)