### PR TITLE
fix(resource/vpn_server): align schema with real Freebox VPN API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.7.0
 	github.com/magefile/mage v1.15.0
-	github.com/nikolalohinski/free-go v1.12.0
+	github.com/nikolalohinski/free-go v1.13.0
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,8 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo=
 github.com/muesli/termenv v0.15.2/go.mod h1:Epx+iuz8sNs7mNKhxzH4fWXGNpZwUaJKRS1noLXviQ8=
-github.com/nikolalohinski/free-go v1.12.0 h1:ElA4eRnJct19k4KQym/POI89Mz+d0d+B/GN2F/7xudQ=
-github.com/nikolalohinski/free-go v1.12.0/go.mod h1:MuBZMApgkYMYZa8OrrQbilBNeAbhWjq5zu9sStCd44A=
+github.com/nikolalohinski/free-go v1.13.0 h1:VIQDYlXTzRuHuNTFj/47sQlHZioaoWoNePSDFZbcbRs=
+github.com/nikolalohinski/free-go v1.13.0/go.mod h1:hyRE8PTkdL9qiAsBHPDgbs9tCch7lKeYbvzFNewiKiY=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/onsi/ginkgo/v2 v2.22.2 h1:/3X8Panh8/WwhU/3Ssa6rCKqPLuAkVY2I0RoyDLySlU=

--- a/internal/resource_vpn_server.go
+++ b/internal/resource_vpn_server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -30,38 +31,62 @@ type vpnServerResource struct {
 }
 
 type vpnServerModel struct {
-	ID         types.String `tfsdk:"id"`
-	Enabled    types.Bool   `tfsdk:"enabled"`
-	ServerPort types.Int64  `tfsdk:"server_port"`
-	ServerIP   types.String `tfsdk:"server_ip"`
-	ServerMask types.String `tfsdk:"server_mask"`
-	PushDHCP   types.Bool   `tfsdk:"push_dhcp"`
-	CA         types.String `tfsdk:"ca"`
+	ID              types.String `tfsdk:"id"`
+	VPNID           types.String `tfsdk:"vpn_id"`
+	Enabled         types.Bool   `tfsdk:"enabled"`
+	EnableIPv4      types.Bool   `tfsdk:"enable_ipv4"`
+	EnableIPv6      types.Bool   `tfsdk:"enable_ipv6"`
+	Port            types.Int64  `tfsdk:"port"`
+	MinPort         types.Int64  `tfsdk:"min_port"`
+	MaxPort         types.Int64  `tfsdk:"max_port"`
+	Cipher          types.String `tfsdk:"cipher"`
+	DisableFragment types.Bool   `tfsdk:"disable_fragment"`
+	UseTCP          types.Bool   `tfsdk:"use_tcp"`
+	IPStart         types.String `tfsdk:"ip_start"`
+	IPEnd           types.String `tfsdk:"ip_end"`
+	IP6Start        types.String `tfsdk:"ip6_start"`
+	IP6End          types.String `tfsdk:"ip6_end"`
 }
 
-func (m *vpnServerModel) toPayload() freeboxTypes.OpenVPNServerConfig {
-	payload := freeboxTypes.OpenVPNServerConfig{
+func (m *vpnServerModel) toPayload() freeboxTypes.VPNServerConfig {
+	payload := freeboxTypes.VPNServerConfig{
 		Enabled:    m.Enabled.ValueBool(),
-		ServerPort: m.ServerPort.ValueInt64(),
-		PushDHCP:   m.PushDHCP.ValueBool(),
+		EnableIPv4: m.EnableIPv4.ValueBool(),
+		EnableIPv6: m.EnableIPv6.ValueBool(),
+		Port:       m.Port.ValueInt64(),
 	}
-	if !m.ServerIP.IsNull() && !m.ServerIP.IsUnknown() {
-		payload.ServerIP = m.ServerIP.ValueString()
-	}
-	if !m.ServerMask.IsNull() && !m.ServerMask.IsUnknown() {
-		payload.ServerMask = m.ServerMask.ValueString()
+	if m.VPNID.ValueString() == string(freeboxTypes.VPNServerIDOpenVPNRouted) || m.VPNID.ValueString() == string(freeboxTypes.VPNServerIDOpenVPNBridge) {
+		payload.ConfOpenVPN = &freeboxTypes.OpenVPNConfig{
+			Cipher:          freeboxTypes.OpenVPNCipher(m.Cipher.ValueString()),
+			DisableFragment: m.DisableFragment.ValueBool(),
+			UseTCP:          m.UseTCP.ValueBool(),
+		}
 	}
 	return payload
 }
 
-func (m *vpnServerModel) fromClientType(config freeboxTypes.OpenVPNServerConfig) {
-	m.ID = basetypes.NewStringValue("openvpn")
+func (m *vpnServerModel) fromClientType(id freeboxTypes.VPNServerID, config freeboxTypes.VPNServerConfig) {
+	m.ID = basetypes.NewStringValue(string(id))
+	m.VPNID = basetypes.NewStringValue(string(id))
 	m.Enabled = basetypes.NewBoolValue(config.Enabled)
-	m.ServerPort = basetypes.NewInt64Value(config.ServerPort)
-	m.ServerIP = basetypes.NewStringValue(config.ServerIP)
-	m.ServerMask = basetypes.NewStringValue(config.ServerMask)
-	m.PushDHCP = basetypes.NewBoolValue(config.PushDHCP)
-	m.CA = basetypes.NewStringValue(config.CA)
+	m.EnableIPv4 = basetypes.NewBoolValue(config.EnableIPv4)
+	m.EnableIPv6 = basetypes.NewBoolValue(config.EnableIPv6)
+	m.Port = basetypes.NewInt64Value(config.Port)
+	m.MinPort = basetypes.NewInt64Value(config.MinPort)
+	m.MaxPort = basetypes.NewInt64Value(config.MaxPort)
+	if config.ConfOpenVPN != nil {
+		m.Cipher = basetypes.NewStringValue(string(config.ConfOpenVPN.Cipher))
+		m.DisableFragment = basetypes.NewBoolValue(config.ConfOpenVPN.DisableFragment)
+		m.UseTCP = basetypes.NewBoolValue(config.ConfOpenVPN.UseTCP)
+	} else {
+		m.Cipher = basetypes.NewStringNull()
+		m.DisableFragment = basetypes.NewBoolNull()
+		m.UseTCP = basetypes.NewBoolNull()
+	}
+	m.IPStart = basetypes.NewStringValue(config.IPStart)
+	m.IPEnd = basetypes.NewStringValue(config.IPEnd)
+	m.IP6Start = basetypes.NewStringValue(config.IP6Start)
+	m.IP6End = basetypes.NewStringValue(config.IP6End)
 }
 
 func (v *vpnServerResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -70,50 +95,86 @@ func (v *vpnServerResource) Metadata(ctx context.Context, req resource.MetadataR
 
 func (v *vpnServerResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manages the OpenVPN server configuration on the Freebox. This is a singleton resource: only one OpenVPN server exists per Freebox. Destroying this resource disables the VPN server.",
+		MarkdownDescription: "Manages one of the built-in VPN server configurations on the Freebox (`pptp`, `openvpn_routed` or `openvpn_bridge`). This is a singleton resource per `vpn_id`: it configures an existing server slot rather than creating a new one. Destroying this resource disables that VPN server.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "Fixed identifier for the singleton OpenVPN server resource",
+				MarkdownDescription: "Identifier of the VPN server, same value as `vpn_id`",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
+			"vpn_id": schema.StringAttribute{
+				MarkdownDescription: "Which VPN server to manage: `pptp`, `openvpn_routed` or `openvpn_bridge`",
+				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString(string(freeboxTypes.VPNServerIDOpenVPNRouted)),
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
 			"enabled": schema.BoolAttribute{
-				MarkdownDescription: "Whether the OpenVPN server is enabled",
+				MarkdownDescription: "Whether the VPN server is enabled",
 				Optional:            true,
 				Computed:            true,
 				Default:             booldefault.StaticBool(true),
 			},
-			"server_port": schema.Int64Attribute{
-				MarkdownDescription: "UDP port the OpenVPN server listens on (default 1194)",
-				Optional:            true,
-				Computed:            true,
-				Default:             int64default.StaticInt64(1194),
-			},
-			"server_ip": schema.StringAttribute{
-				MarkdownDescription: "VPN subnet IP address (e.g. \"10.8.0.0\")",
-				Optional:            true,
-				Computed:            true,
-			},
-			"server_mask": schema.StringAttribute{
-				MarkdownDescription: "VPN subnet mask (e.g. \"255.255.255.0\")",
-				Optional:            true,
-				Computed:            true,
-			},
-			"push_dhcp": schema.BoolAttribute{
-				MarkdownDescription: "Whether to push DHCP settings to clients",
+			"enable_ipv4": schema.BoolAttribute{
+				MarkdownDescription: "Enable IPv4 (not relevant for openvpn_bridge and pptp)",
 				Optional:            true,
 				Computed:            true,
 				Default:             booldefault.StaticBool(false),
 			},
-			"ca": schema.StringAttribute{
-				MarkdownDescription: "CA certificate in PEM format (read-only, set by Freebox)",
+			"enable_ipv6": schema.BoolAttribute{
+				MarkdownDescription: "Enable IPv6 (not relevant for openvpn_bridge and pptp)",
+				Optional:            true,
 				Computed:            true,
-				Sensitive:           true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
+				Default:             booldefault.StaticBool(false),
+			},
+			"port": schema.Int64Attribute{
+				MarkdownDescription: "Server port (only editable when vpn_id is openvpn_routed or openvpn_bridge)",
+				Optional:            true,
+				Computed:            true,
+				Default:             int64default.StaticInt64(1194),
+			},
+			"min_port": schema.Int64Attribute{
+				MarkdownDescription: "Read-only lower bound of the available port range",
+				Computed:            true,
+			},
+			"max_port": schema.Int64Attribute{
+				MarkdownDescription: "Read-only upper bound of the available port range",
+				Computed:            true,
+			},
+			"cipher": schema.StringAttribute{
+				MarkdownDescription: "Cipher used by the OpenVPN server: `blowfish`, `aes128` or `aes256` (only relevant when vpn_id is openvpn_routed or openvpn_bridge)",
+				Optional:            true,
+				Computed:            true,
+			},
+			"disable_fragment": schema.BoolAttribute{
+				MarkdownDescription: "Disable the fragment configuration option (only relevant when vpn_id is openvpn_routed or openvpn_bridge)",
+				Optional:            true,
+				Computed:            true,
+			},
+			"use_tcp": schema.BoolAttribute{
+				MarkdownDescription: "Use TCP instead of UDP (only relevant when vpn_id is openvpn_routed or openvpn_bridge)",
+				Optional:            true,
+				Computed:            true,
+			},
+			"ip_start": schema.StringAttribute{
+				MarkdownDescription: "Read-only IPv4 pool range start for clients",
+				Computed:            true,
+			},
+			"ip_end": schema.StringAttribute{
+				MarkdownDescription: "Read-only IPv4 pool range end for clients",
+				Computed:            true,
+			},
+			"ip6_start": schema.StringAttribute{
+				MarkdownDescription: "Read-only IPv6 pool range start for clients",
+				Computed:            true,
+			},
+			"ip6_end": schema.StringAttribute{
+				MarkdownDescription: "Read-only IPv6 pool range end for clients",
+				Computed:            true,
 			},
 		},
 	}
@@ -144,16 +205,18 @@ func (v *vpnServerResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	response, err := v.client.UpdateOpenVPNServerConfig(ctx, model.toPayload())
+	id := freeboxTypes.VPNServerID(model.VPNID.ValueString())
+
+	response, err := v.client.UpdateVPNServerConfig(ctx, id, model.toPayload())
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Failed to configure OpenVPN server",
+			"Failed to configure VPN server",
 			err.Error(),
 		)
 		return
 	}
 
-	model.fromClientType(response)
+	model.fromClientType(id, response)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
 }
@@ -166,16 +229,18 @@ func (v *vpnServerResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	response, err := v.client.GetOpenVPNServerConfig(ctx)
+	id := freeboxTypes.VPNServerID(model.VPNID.ValueString())
+
+	response, err := v.client.GetVPNServerConfig(ctx, id)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Failed to read OpenVPN server config",
+			"Failed to read VPN server config",
 			err.Error(),
 		)
 		return
 	}
 
-	model.fromClientType(response)
+	model.fromClientType(id, response)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
 }
@@ -188,16 +253,18 @@ func (v *vpnServerResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	response, err := v.client.UpdateOpenVPNServerConfig(ctx, model.toPayload())
+	id := freeboxTypes.VPNServerID(model.VPNID.ValueString())
+
+	response, err := v.client.UpdateVPNServerConfig(ctx, id, model.toPayload())
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Failed to update OpenVPN server config",
+			"Failed to update VPN server config",
 			err.Error(),
 		)
 		return
 	}
 
-	model.fromClientType(response)
+	model.fromClientType(id, response)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
 }
@@ -210,17 +277,20 @@ func (v *vpnServerResource) Delete(ctx context.Context, req resource.DeleteReque
 		return
 	}
 
+	id := freeboxTypes.VPNServerID(model.VPNID.ValueString())
+
 	payload := model.toPayload()
 	payload.Enabled = false
 
-	if _, err := v.client.UpdateOpenVPNServerConfig(ctx, payload); err != nil {
+	if _, err := v.client.UpdateVPNServerConfig(ctx, id, payload); err != nil {
 		resp.Diagnostics.AddError(
-			"Failed to disable OpenVPN server",
+			"Failed to disable VPN server",
 			err.Error(),
 		)
 	}
 }
 
 func (v *vpnServerResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), "openvpn")...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("vpn_id"), req.ID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
 }


### PR DESCRIPTION
## Summary
- `freebox_vpn_server` was built against a client that hit a nonexistent endpoint (`vpn/openvpn/`) with wrong field names, so `terraform apply` always failed with a 404 `invalid_request`.
- Reworks the resource around the real `/vpn/{id}/config/` API (`pptp`, `openvpn_routed`, `openvpn_bridge`, see https://dev.freebox.fr/sdk/os/vpn/): adds a `vpn_id` attribute and replaces `server_port`/`server_ip`/`server_mask`/`push_dhcp`/`ca` with the documented fields (`port`, `min_port`, `max_port`, `enable_ipv4`, `enable_ipv6`, `cipher`, `disable_fragment`, `use_tcp`, `ip_start`, `ip_end`, `ip6_start`, `ip6_end`).

**Depends on** nikolalohinski/free-go#54 — this PR's `go.mod` still points at the released `free-go` v1.12.0, so CI will fail to build against the new client methods until that PR is merged and tagged (or a temporary `replace` directive is added).

## Test plan
- [x] `go build ./...` (verified locally against the free-go fix via a local `go.work`, not committed)
- [x] Verified end-to-end against a live Freebox: `freebox_vpn_server.main` (previously failing with a 404) now creates and reads successfully via `terraform apply`