### PR TITLE
docs: add missing freebox_dhcp_leases entry to SUMMARY.md

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -20,6 +20,7 @@
   - [Data Sources]()
     - [freebox_api_version](./data-sources/api_version.md)
     - [freebox_dhcp_lease](./data-sources/dhcp_lease.md)
+    - [freebox_dhcp_leases](./data-sources/dhcp_leases.md)
     - [freebox_lan_config](./data-sources/lan_config.md)
     - [freebox_lan_interface_host](./data-sources/lan_interface_host.md)
     - [freebox_lan_interface_hosts](./data-sources/lan_interface_hosts.md)


### PR DESCRIPTION
## Summary
- `freebox_dhcp_leases` data source has had docs (`docs/data-sources/dhcp_leases.md`) and an example since it was added, but was never linked from the mdBook table of contents (`book/src/SUMMARY.md`).

## Test plan
- [x] Verified `docs/data-sources/dhcp_leases.md` and `examples/data.freebox_dhcp_leases.tf` already exist
- [x] Added the missing TOC entry